### PR TITLE
update spatial docker image to include squidpy and tissuumaps viewer func

### DIFF
--- a/day3_spatial_transcriptomics/docker/Dockerfile
+++ b/day3_spatial_transcriptomics/docker/Dockerfile
@@ -2,11 +2,32 @@ FROM jupyter/scipy-notebook:latest
 
 USER root
 
+# install libvips for TissUUmaps
 RUN apt-get update
-RUN apt-get install libvips -y
+#RUN apt-get install libvips -y
+RUN apt install libvips-dev -y
+RUN apt-get install openslide-tools	
 
 user jovyan
 
+# create directory for TissUUmaps
+RUN mkdir -p ~/.tissuumaps/plugins
+
+# install TissUUmaps feature space plugin
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.yml
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.py
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.js
+
+# install dependencies for interaction
 RUN pip install tissuumaps
 RUN pip install pooch
 RUN pip install scikit-image
+RUN pip install spatial-analysis-toolkit[tissuumaps]
+
+# install dependencies for spatial analysis
+#RUN pip install scanpy>=1.9.0
+#RUN pip install scvi-tools>=0.15.4
+#RUN pip install git+https://github.com/theislab/squidpy@master
+#RUN pip install git+https://github.com/almaan/eggplant@master
+#RUN pip install nb_black
+#RUN pip install scikit-misc

--- a/day3_spatial_transcriptomics/docker/Dockerfile
+++ b/day3_spatial_transcriptomics/docker/Dockerfile
@@ -18,6 +18,11 @@ RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugin
 RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.py
 RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.js
 
+# install TissUUmaps histogram plugin
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Plot_Histogram.yml
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Plot_Histogram.py
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Plot_Histogram.js
+
 # install dependencies for interaction
 RUN pip install tissuumaps
 RUN pip install pooch

--- a/day3_spatial_transcriptomics/docker/README.md
+++ b/day3_spatial_transcriptomics/docker/README.md
@@ -1,8 +1,8 @@
-First, build the docker image.
+First, build the docker image. If you want to use the cached build steps, you can omit the `--no-cache` flag. However, this may result in building with outdated libraries.
 
 ```bash
-cd /path/to/day3_spatial_transcriptomics
-docker build . -t jupyterlab-tissuumaps
+cd /path/to/day3_spatial_transcriptomics/docker
+docker build --no-cache . -t jupyterlab-tissuumaps
 ```
 
 Next, start the jupyterlab-tissuumaps container. 
@@ -10,6 +10,12 @@ Next, start the jupyterlab-tissuumaps container.
 ```bash
 docker run -it --rm -p 10000:8888 -p 5100-5200:5100-5200 -v "${PWD}":/home/jovyan/work jupyterlab-tissuumaps
 
+```
+
+If you have memory issues, you can increase the maximum memory allocation using the `--memory` option. For example, if you want to allow up to 6000 MB of memory:
+
+```bash
+docker run -it --rm --memory 6000m -p 10000:8888 -p 5100-5200:5100-5200 -v "${PWD}":/home/jovyan/work jupyterlab-tissuumaps
 ```
 
 Open a web browser and connect to the jupyter server. You will see a message like the following in your terminal. This gives the token required to connect to the jupyter server. Copy the token following `?token=`. In your browser navigate to `http://localhost:10000/?token=<token>`. In this example, it would be `http://localhost:10000/?token=eb26702ff43fd03498ce8b78f49dba2eded58d903aaa7f42`
@@ -23,4 +29,4 @@ Open a web browser and connect to the jupyter server. You will see a message lik
 
 ```
 
-Navigate to the `work` directory in the file browser and run the `tissuumaps_test.ipynb` notebook
+Navigate to the `work` directory in the file browser and run the `tissuumaps_test.ipynb` or `squidpy_tissuumaps.ipynb` notebook.

--- a/day3_spatial_transcriptomics/docker/README.md
+++ b/day3_spatial_transcriptomics/docker/README.md
@@ -1,0 +1,26 @@
+First, build the docker image.
+
+```bash
+cd /path/to/day3_spatial_transcriptomics
+docker build . -t jupyterlab-tissuumaps
+```
+
+Next, start the jupyterlab-tissuumaps container. 
+
+```bash
+docker run -it --rm -p 10000:8888 -p 5100-5200:5100-5200 -v "${PWD}":/home/jovyan/work jupyterlab-tissuumaps
+
+```
+
+Open a web browser and connect to the jupyter server. You will see a message like the following in your terminal. This gives the token required to connect to the jupyter server. Copy the token following `?token=`. In your browser navigate to `http://localhost:10000/?token=<token>`. In this example, it would be `http://localhost:10000/?token=eb26702ff43fd03498ce8b78f49dba2eded58d903aaa7f42`
+
+```
+    To access the server, open this file in a browser:
+        file:///home/jovyan/.local/share/jupyter/runtime/jpserver-8-open.html
+    Or copy and paste one of these URLs:
+        http://94a824b3af9e:8888/lab?token=eb26702ff43fd03498ce8b78f49dba2eded58d903aaa7f42
+     or http://127.0.0.1:8888/lab?token=eb26702ff43fd03498ce8b78f49dba2eded58d903aaa7f42
+
+```
+
+Navigate to the `work` directory in the file browser and run the `tissuumaps_test.ipynb` notebook

--- a/day3_spatial_transcriptomics/docker/squidpy_tissuumaps.ipynb
+++ b/day3_spatial_transcriptomics/docker/squidpy_tissuumaps.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5becfb71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root: * TissUUmaps version: 3.0.8.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "import squidpy as sq\n",
+    "\n",
+    "from spatial_analysis_toolkit.view import tissuumaps_notebook_viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "945fc57c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e113d65792c94a23897734f806d2fd7b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0.00/303M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8695ab820bf145e8a5c3dfb9cc2d7544",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0.00/65.5M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# load the pre-processed dataset\n",
+    "img = sq.datasets.visium_fluo_image_crop()\n",
+    "adata = sq.datasets.visium_fluo_adata_crop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "209168ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pyvips:VIPS: residual reducev by 0.5\n",
+      "INFO:pyvips:VIPS: reducev: 13 point mask\n",
+      "INFO:pyvips:VIPS: reducev: using vector path\n",
+      "INFO:pyvips:VIPS: residual reduceh by 0.5\n",
+      "INFO:pyvips:VIPS: reduceh: 13 point mask\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating project file /home/jovyan/work/_project.tmap\n",
+      "Loading url:  http://localhost:5101/_project.tmap?path=home/jovyan/work\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<iframe src=\"http://localhost:5101/_project.tmap?path=home/jovyan/work\" style=\"width: 100%; height: 700px; border: none\" id=\"tissUUmapsViewer_499b7058b7\" allowfullscreen></iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tissuumaps_notebook_viewer(adata=adata, image_container=img, image_path=\"test3.tif\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e54c36fc-740c-48dc-b7ad-4b416734a5a1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR updates the docker image for the interactive spatial analysis section to:

- include the requirements from the python part of the spatial activity (from the `requirements.txt` in #4 )
- add a TissUUmaps plugin for exploring feature space (e.g., select observations from UMAP space and view on image)
- add some convenience functions I wrote to view `AnnData` and squidpy `ImageContainer`in TissUUmaps
- add an example of downloading and viewing squidpy example in TissUUmaps


<img width="1508" alt="Screenshot 2022-04-09 at 09 48 09" src="https://user-images.githubusercontent.com/1120672/162564046-372cb32f-4525-4f25-9bd1-56179b6f1f22.png">

