### PR TITLE
Add dockerfiles

### DIFF
--- a/containers/container_jupyter/Dockerfile
+++ b/containers/container_jupyter/Dockerfile
@@ -1,0 +1,47 @@
+FROM jupyter/minimal-notebook:latest
+
+USER root
+RUN cat /etc/skel/.bashrc >> /etc/bash.bashrc
+
+RUN apt-get update
+
+RUN apt-get install -y \
+curl \
+libhdf5-dev \
+gcc \
+g++ \
+libtool \
+openslide-tools	\
+libvips-dev
+
+# change back to notebook user
+USER $NB_UID
+
+ENV CONDA=/opt/conda/bin
+
+ENV PART=day2_multi-omics
+COPY $PART/environment.yml .
+RUN $CONDA/conda env create \
+-n $PART \
+-f environment.yml
+
+ENV PART=day3_spatial_transcriptomics
+COPY $PART/environment.yml .
+RUN $CONDA/conda env create \
+-n $PART \
+-f environment.yml
+
+RUN /opt/conda/bin/conda install -y nb_conda_kernels
+
+# create directory for TissUUmaps
+RUN mkdir -p ~/.tissuumaps/plugins
+
+# install TissUUmaps feature space plugin
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.yml
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.py
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Feature_Space.js
+
+# install TissUUmaps histogram plugin
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Plot_Histogram.yml
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Plot_Histogram.py
+RUN wget -P ~/.tissuumaps/plugins https://tissuumaps.github.io/TissUUmaps/plugins/Plot_Histogram.js

--- a/containers/container_jupyter/before_build.sh
+++ b/containers/container_jupyter/before_build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+cd ../..
+
+pip_to_conda () {
+  REQ=$1
+  OUT=$2
+
+  echo """
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:""" > $OUT 
+
+ grep -v "^#" $REQ | sed 's/^/    - /g' >> $OUT
+
+}
+
+for DIR in day?_*
+do
+    mkdir -p containers/container_jupyter/$DIR
+    # cp $DIR/R_requirements.R container_rstudio/$DIR
+
+    if [ -f $DIR/environment.yml ]
+    then
+        cp $DIR/environment.yml containers/container_jupyter/$DIR
+    else 
+        echo "translating $PWD/$DIR/requirements.txt"
+        pip_to_conda $DIR/requirements.txt containers/container_jupyter/$DIR/environment.yml
+    fi
+done

--- a/containers/container_jupyter/day1_RNA_velocity/environment.yml
+++ b/containers/container_jupyter/day1_RNA_velocity/environment.yml
@@ -1,0 +1,11 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - anndata >= 0.7.4
+    - scanpy >= 1.6.0
+    - scvelo >= 0.2.2

--- a/containers/container_jupyter/day1_differential_analysis/environment.yml
+++ b/containers/container_jupyter/day1_differential_analysis/environment.yml
@@ -1,0 +1,8 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:

--- a/containers/container_jupyter/day1_python_and_R/environment.yml
+++ b/containers/container_jupyter/day1_python_and_R/environment.yml
@@ -1,0 +1,14 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - numpy
+    - scipy
+    - rpy2
+    - matplotlib
+    - sinfo
+    - pandas

--- a/containers/container_jupyter/day2_multi-omics/environment.yml
+++ b/containers/container_jupyter/day2_multi-omics/environment.yml
@@ -1,0 +1,22 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - leidenalg
+  - pip
+  - pip:
+    - muon==0.1.2
+    - numpy
+    - scipy
+    - pandas
+    - matplotlib
+    - seaborn
+    - scanpy==1.9.1
+    - dask
+    - muon[atac]
+    - mofapy2==0.6.4
+    - pyranges
+    - pyensembl==1.9.4
+    - sklearn
+    - ipykernel
+  

--- a/containers/container_jupyter/day3_interactive_visualization_iSEE/environment.yml
+++ b/containers/container_jupyter/day3_interactive_visualization_iSEE/environment.yml
@@ -1,0 +1,8 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:

--- a/containers/container_jupyter/day3_spatial_transcriptomics/environment.yml
+++ b/containers/container_jupyter/day3_spatial_transcriptomics/environment.yml
@@ -1,0 +1,19 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - scanpy>=1.9.0
+    - scvi-tools>=0.15.4
+    - git+https://github.com/theislab/squidpy@master
+    - git+https://github.com/giovp/eggplant@master
+    - scikit-misc
+    - tangram-sc
+    - tissuumaps
+    - pooch
+    - scikit-image
+    - spatial-analysis-toolkit[tissuumaps]
+    - ipykernel

--- a/containers/container_jupyter/day4_deep_generative_networks/environment.yml
+++ b/containers/container_jupyter/day4_deep_generative_networks/environment.yml
@@ -1,0 +1,28 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - keras
+    - tensorflow
+    - torch
+    - numpy
+    - scipy
+    - pandas
+    - matplotlib
+    - pydotplus
+    - sklearn
+    - scanpy
+    - os
+    - gseapy
+    - seaborn
+    - anndata
+    - statsmodels
+    - scvi
+    - numba
+    - pytables
+    - leidenalg
+    - skmisc

--- a/containers/container_jupyter/run_container.sh
+++ b/containers/container_jupyter/run_container.sh
@@ -1,0 +1,8 @@
+docker run \
+-e NB_UMASK=002 \
+-e JUPYTER_ENABLE_LAB=yes \
+-e JUPYTER_TOKEN=test123 \
+-p 8888:8888 \
+-p 5100-5200:5100-5200 \
+geertvangeest/adv_singlecell_2022-jupyter \
+start-notebook.sh

--- a/containers/container_rstudio/.profile
+++ b/containers/container_rstudio/.profile
@@ -1,0 +1,6 @@
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi

--- a/containers/container_rstudio/Dockerfile
+++ b/containers/container_rstudio/Dockerfile
@@ -1,0 +1,66 @@
+FROM rocker/rstudio:4.1.2
+
+RUN sudo apt-get update
+
+RUN sudo apt-get install -y \
+libxt6 \
+libgl1-mesa-glx \
+libcurl4-openssl-dev \
+libglpk-dev \
+libxml2-dev \
+libproj-dev \
+libudunits2-dev \
+libgdal-dev \
+libgsl-dev \
+libbz2-dev \
+libclang-dev \
+libmagick++-6.q16-dev
+
+USER rstudio
+
+WORKDIR /home/rstudio
+
+ENV CONDA=/home/rstudio/.local/share/r-miniconda/bin/
+
+RUN R -e "install.packages('reticulate')"
+RUN R -e "reticulate::install_miniconda()"
+RUN $CONDA/conda init bash
+COPY .profile /home/rstudio/
+
+ENV PART=day1_python_and_R
+COPY $PART/R_requirements.R .
+RUN Rscript R_requirements.R
+COPY $PART/environment.yml .
+RUN $CONDA/conda env create \
+-n $PART \
+-f environment.yml
+
+ENV PART=day1_RNA_velocity
+COPY $PART/R_requirements.R .
+RUN Rscript R_requirements.R
+COPY $PART/environment.yml .
+RUN $CONDA/conda env create \
+-n $PART \
+-f environment.yml
+
+ENV PART=day3_interactive_visualization_iSEE
+COPY $PART/R_requirements.R .
+RUN Rscript R_requirements.R
+
+ENV PART=day4_deep_generative_networks
+COPY $PART/R_requirements.R .
+RUN Rscript R_requirements.R
+COPY $PART/environment.yml .
+RUN $CONDA/conda env create \
+-n $PART \
+-f environment.yml
+
+ENV PART=day1_differential_analysis
+COPY $PART/R_requirements.R .
+RUN Rscript R_requirements.R
+
+ENV PART=day3_spatial_transcriptomics
+COPY $PART/R_requirements.R .
+RUN Rscript R_requirements.R
+
+USER root

--- a/containers/container_rstudio/before_build.sh
+++ b/containers/container_rstudio/before_build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+cd ../..
+
+pip_to_conda () {
+  REQ=$1
+  OUT=$2
+
+  echo """
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:""" > $OUT 
+
+ grep -v "^#" $REQ | sed 's/^/    - /g' >> $OUT
+
+}
+
+for DIR in day?_*
+do
+    mkdir -p containers/container_rstudio/$DIR
+    cp $DIR/R_requirements.R containers/container_rstudio/$DIR
+
+    if [ -f $DIR/environment.yml ]
+    then
+        cp $DIR/environment.yml containers/container_rstudio/$DIR
+    else 
+        pip_to_conda $DIR/requirements.txt containers/container_rstudio/$DIR/environment.yml
+    fi
+done

--- a/containers/container_rstudio/day1_RNA_velocity/R_requirements.R
+++ b/containers/container_rstudio/day1_RNA_velocity/R_requirements.R
@@ -1,0 +1,35 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c("velociraptor", "SummarizedExperiment", "SingleCellExperiment", 
+          "tximeta", "eisaR", "fishpond", "basilisk", "Biostrings", "BSgenome",
+          "GenomicFeatures", "rjson", "scRNAseq", "zellkonverter", "cowplot",
+          "knitr", "rmarkdown", "htmltools", "BiocStyle", "shiny", "dplyr",
+          "ggplot2", "tidyr", "reticulate", "scuttle", "scran", "scater",
+          "veloviz")
+
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day1_RNA_velocity/environment.yml
+++ b/containers/container_rstudio/day1_RNA_velocity/environment.yml
@@ -1,0 +1,11 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - anndata >= 0.7.4
+    - scanpy >= 1.6.0
+    - scvelo >= 0.2.2

--- a/containers/container_rstudio/day1_RNA_velocity/requirements.txt
+++ b/containers/container_rstudio/day1_RNA_velocity/requirements.txt
@@ -1,0 +1,7 @@
+# requirements.txt
+#   list of items to be installed by pip
+#   (see https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+#   typically used in `pip install -r requirements.txt`
+anndata >= 0.7.4
+scanpy >= 1.6.0
+scvelo >= 0.2.2

--- a/containers/container_rstudio/day1_differential_analysis/R_requirements.R
+++ b/containers/container_rstudio/day1_differential_analysis/R_requirements.R
@@ -1,0 +1,34 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c("miloR","muscat","devtools", "distinct",
+          "condiments", "nebula", "sechm"
+          )
+
+devtools::install_github("dynverse/dyntoy")
+devtools::install_github("fionarhuang/treeclimbR")
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day1_differential_analysis/environment.yml
+++ b/containers/container_rstudio/day1_differential_analysis/environment.yml
@@ -1,0 +1,8 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:

--- a/containers/container_rstudio/day1_differential_analysis/requirements.txt
+++ b/containers/container_rstudio/day1_differential_analysis/requirements.txt
@@ -1,0 +1,4 @@
+# requirements.txt
+#   list of items to be installed by pip
+#   (see https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+#   typically used in `pip install -r requirements.txt`

--- a/containers/container_rstudio/day1_python_and_R/R_requirements.R
+++ b/containers/container_rstudio/day1_python_and_R/R_requirements.R
@@ -1,0 +1,30 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c("devtools", "reticulate", "knitr", "rmarkdown", "ggplot2")
+
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day1_python_and_R/environment.yml
+++ b/containers/container_rstudio/day1_python_and_R/environment.yml
@@ -1,0 +1,14 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - numpy
+    - scipy
+    - rpy2
+    - matplotlib
+    - sinfo
+    - pandas

--- a/containers/container_rstudio/day1_python_and_R/requirements.txt
+++ b/containers/container_rstudio/day1_python_and_R/requirements.txt
@@ -1,0 +1,10 @@
+# requirements.txt
+#   list of items to be installed by pip
+#   (see https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+#   typically used in `pip install -r requirements.txt`
+numpy
+scipy
+rpy2
+matplotlib
+sinfo
+pandas

--- a/containers/container_rstudio/day2_multi-omics/R_requirements.R
+++ b/containers/container_rstudio/day2_multi-omics/R_requirements.R
@@ -1,0 +1,30 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c()
+
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day2_multi-omics/environment.yml
+++ b/containers/container_rstudio/day2_multi-omics/environment.yml
@@ -1,0 +1,22 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - leidenalg
+  - pip
+  - pip:
+    - muon==0.1.2
+    - numpy
+    - scipy
+    - pandas
+    - matplotlib
+    - seaborn
+    - scanpy==1.9.1
+    - dask
+    - muon[atac]
+    - mofapy2==0.6.4
+    - pyranges
+    - pyensembl==1.9.4
+    - sklearn
+    - ipykernel
+  

--- a/containers/container_rstudio/day2_multi-omics/requirements.txt
+++ b/containers/container_rstudio/day2_multi-omics/requirements.txt
@@ -1,0 +1,17 @@
+# requirements.txt
+#   list of items to be installed by pip
+#   (see https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+#   typically used in `pip install -r requirements.txt`
+
+numpy
+scipy
+pandas
+matplotlib
+seaborn
+scanpy == 1.9.1
+dask
+muon[atac]
+mofapy2
+pyranges
+pyensembl
+sklearn

--- a/containers/container_rstudio/day3_interactive_visualization_iSEE/R_requirements.R
+++ b/containers/container_rstudio/day3_interactive_visualization_iSEE/R_requirements.R
@@ -1,0 +1,33 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c("SummarizedExperiment", "SingleCellExperiment",
+          "TENxPBMCData", "iSEE", "iSEEu", "scater", "scuttle", "scran",
+          "BiocSingular", "SingleR", "celldex", "igraph", "knitr", "rmarkdown",
+          "htmltools", "BiocStyle", "shiny")
+
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day3_interactive_visualization_iSEE/environment.yml
+++ b/containers/container_rstudio/day3_interactive_visualization_iSEE/environment.yml
@@ -1,0 +1,8 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:

--- a/containers/container_rstudio/day3_interactive_visualization_iSEE/requirements.txt
+++ b/containers/container_rstudio/day3_interactive_visualization_iSEE/requirements.txt
@@ -1,0 +1,4 @@
+# requirements.txt
+#   list of items to be installed by pip
+#   (see https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+#   typically used in `pip install -r requirements.txt`

--- a/containers/container_rstudio/day3_spatial_transcriptomics/R_requirements.R
+++ b/containers/container_rstudio/day3_spatial_transcriptomics/R_requirements.R
@@ -1,0 +1,30 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c("zellkonverter","SpatialExperiment","ggspavis", "scater", "scran")
+
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day3_spatial_transcriptomics/environment.yml
+++ b/containers/container_rstudio/day3_spatial_transcriptomics/environment.yml
@@ -1,0 +1,19 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - scanpy>=1.9.0
+    - scvi-tools>=0.15.4
+    - git+https://github.com/theislab/squidpy@master
+    - git+https://github.com/giovp/eggplant@master
+    - scikit-misc
+    - tangram-sc
+    - tissuumaps
+    - pooch
+    - scikit-image
+    - spatial-analysis-toolkit[tissuumaps]
+    - ipykernel

--- a/containers/container_rstudio/day3_spatial_transcriptomics/requirements.txt
+++ b/containers/container_rstudio/day3_spatial_transcriptomics/requirements.txt
@@ -1,0 +1,6 @@
+scanpy>=1.9.0
+scvi-tools>=0.15.4
+git+https://github.com/theislab/squidpy@master
+git+https://github.com/giovp/eggplant@master
+scikit-misc
+tangram-sc

--- a/containers/container_rstudio/day4_deep_generative_networks/R_requirements.R
+++ b/containers/container_rstudio/day4_deep_generative_networks/R_requirements.R
@@ -1,0 +1,37 @@
+# R script to install requirements for exercises -------------------------------
+
+## global variables (edit in this section) -------------------------------------
+pkgs <- c("reticulate", "SummarizedExperiment", "SingleCellExperiment","igraph","BiocNeighbors",
+          "keras", "tensorflow", "Rtsne", "rsvd", "RColorBrewer","dplyr","reshape2",
+          "gridExtra", "umap", "tibble", "ggplot2", "cowplot","scater","scran","batchelor",
+          "knitr", "rmarkdown", "htmltools", "BiocStyle","BiocSingular", "shiny","tidyr","BiocParallel",
+          "ComplexHeatmap","tximeta","GenomicFeatures","AnnotationDbi","org.Mm.eg.db","rtracklayer")
+
+
+
+
+
+## install Bioconductor --------------------------------------------------------
+biocversion <- "3.14"
+if (!require("BiocManager", quietly = TRUE)) {
+    install.packages("BiocManager")
+}
+
+if (!identical(as.character(BiocManager::version()), biocversion)) {
+    BiocManager::install(version = biocversion)
+}
+
+## install and check package loading -------------------------------------------
+for (pkg in basename(pkgs)) {
+    BiocManager::install(pkg, ask = FALSE, update = FALSE);
+
+    if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
+        write(paste0("Installation of package ",
+                     pkg,
+                     " exited with non-zero exit status"),
+                     stdout())
+        quit(status = 1, save = "no")
+    }
+}
+
+sessionInfo()

--- a/containers/container_rstudio/day4_deep_generative_networks/environment.yml
+++ b/containers/container_rstudio/day4_deep_generative_networks/environment.yml
@@ -1,0 +1,27 @@
+
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - keras
+    - tensorflow
+    - torch
+    - numpy
+    - scipy
+    - pandas
+    - matplotlib
+    - pydotplus
+    - sklearn
+    - scanpy
+    - gseapy
+    - seaborn
+    - anndata
+    - statsmodels
+    - scvi
+    - numba
+    - tables
+    - leidenalg
+    - scikit-misc

--- a/containers/container_rstudio/day4_deep_generative_networks/requirements.txt
+++ b/containers/container_rstudio/day4_deep_generative_networks/requirements.txt
@@ -1,0 +1,24 @@
+# requirements.txt
+#   list of items to be installed by pip
+#   (see https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+#   typically used in `pip install -r requirements.txt`
+keras
+tensorflow
+torch
+numpy
+scipy
+pandas
+matplotlib
+pydotplus
+sklearn
+scanpy
+os
+gseapy
+seaborn
+anndata
+statsmodels
+scvi
+numba
+pytables
+leidenalg
+skmisc

--- a/containers/container_rstudio/run_container.sh
+++ b/containers/container_rstudio/run_container.sh
@@ -1,0 +1,5 @@
+docker run \
+--rm \
+-e PASSWORD=test123 \
+-p 8787:8787 \
+geertvangeest/adv_singlecell_2022-rstudio

--- a/containers/part_overview.csv
+++ b/containers/part_overview.csv
@@ -1,0 +1,8 @@
+﻿part,container,conda_env
+day1_RNA_velocity,rstudio,day1_RNA_velocity
+day1_differential_analysis,rstudio,day1_differential_analysis
+day1_python_and_R,rstudio,day1_python_and_R
+day2_multi-omics,jupyter,day2_multi-omics
+day3_interactive_visualization_iSEE,rstudio,day3_interactive_visualization_iSEE
+day3_spatial_transcriptomics,jupyter,day3_spatial_transcriptomics
+day4_deep_generative_networks,rstudio,day4_deep_generative_networks

--- a/day1_RNA_velocity/R_requirements.R
+++ b/day1_RNA_velocity/R_requirements.R
@@ -25,7 +25,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day1_differential_analysis/R_requirements.R
+++ b/day1_differential_analysis/R_requirements.R
@@ -22,7 +22,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day1_differential_analysis/R_requirements.R
+++ b/day1_differential_analysis/R_requirements.R
@@ -2,9 +2,11 @@
 
 ## global variables (edit in this section) -------------------------------------
 pkgs <- c("miloR","muscat","devtools", "distinct",
-          "condiments", "nebula", "sechm", "dynverse/dyntoy",
-          "fionarhuang/treeclimbR")
+          "condiments", "nebula", "sechm"
+          )
 
+devtools::install_github("dynverse/dyntoy")
+devtools::install_github("fionarhuang/treeclimbR")
 
 ## install Bioconductor --------------------------------------------------------
 biocversion <- "3.14"

--- a/day1_python_and_R/R_requirements.R
+++ b/day1_python_and_R/R_requirements.R
@@ -20,7 +20,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day2_multi-omics/R_requirements.R
+++ b/day2_multi-omics/R_requirements.R
@@ -20,7 +20,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day2_multi-omics/environment.yml
+++ b/day2_multi-omics/environment.yml
@@ -18,3 +18,5 @@ dependencies:
     - pyranges
     - pyensembl==1.9.4
     - sklearn
+    - ipykernel
+  

--- a/day3_interactive_visualization_iSEE/R_requirements.R
+++ b/day3_interactive_visualization_iSEE/R_requirements.R
@@ -23,7 +23,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day3_spatial_transcriptomics/R_requirements.R
+++ b/day3_spatial_transcriptomics/R_requirements.R
@@ -20,7 +20,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day3_spatial_transcriptomics/requirements.txt
+++ b/day3_spatial_transcriptomics/requirements.txt
@@ -4,3 +4,8 @@ git+https://github.com/theislab/squidpy@master
 git+https://github.com/giovp/eggplant@master
 scikit-misc
 tangram-sc
+tissuumaps
+pooch
+scikit-image
+spatial-analysis-toolkit[tissuumaps]
+ipykernel

--- a/day4_deep_generative_networks/R_requirements.R
+++ b/day4_deep_generative_networks/R_requirements.R
@@ -2,8 +2,8 @@
 
 ## global variables (edit in this section) -------------------------------------
 pkgs <- c("reticulate", "SummarizedExperiment", "SingleCellExperiment","igraph","BiocNeighbors",
-          "keras", "tensorflow", "Matrix", "Rtsne", "rsvd", "RColorBrewer","dplyr","reshape2",
-          "gridextra", "umap", "tibble", "ggplot2", "cowplot","scater","scran","swissknife","batchelor",
+          "keras", "tensorflow", "Rtsne", "rsvd", "RColorBrewer","dplyr","reshape2",
+          "gridExtra", "umap", "tibble", "ggplot2", "cowplot","scater","scran","batchelor",
           "knitr", "rmarkdown", "htmltools", "BiocStyle","BiocSingular", "shiny","tidyr","BiocParallel",
           "ComplexHeatmap","tximeta","GenomicFeatures","AnnotationDbi","org.Mm.eg.db","rtracklayer")
 

--- a/day4_deep_generative_networks/R_requirements.R
+++ b/day4_deep_generative_networks/R_requirements.R
@@ -27,7 +27,7 @@ for (pkg in basename(pkgs)) {
 
     if (! library(pkg, character.only = TRUE, logical.return = TRUE)) {
         write(paste0("Installation of package ",
-                     p,
+                     pkg,
                      " exited with non-zero exit status"),
                      stdout())
         quit(status = 1, save = "no")

--- a/day4_deep_generative_networks/requirements.txt
+++ b/day4_deep_generative_networks/requirements.txt
@@ -12,13 +12,12 @@ matplotlib
 pydotplus
 sklearn
 scanpy
-os
 gseapy
 seaborn
 anndata
 statsmodels
 scvi
 numba
-pytables
+tables
 leidenalg
-skmisc
+scikit-misc


### PR DESCRIPTION
Two docker images were created:
- based on rstudio/rocker
- based on jupyter stacks

Python packages have been installed in conda environments named after their respective parts of the course. I assumed day2_multi-omics and day3_spatial_transcriptomics required a jupyter container. See the table below. 

| part                                	| container 	| conda_env                           	|
|-------------------------------------	|-----------	|-------------------------------------	|
| day1_RNA_velocity                   	| rstudio   	| day1_RNA_velocity                   	|
| day1_differential_analysis          	| rstudio   	| day1_differential_analysis          	|
| day1_python_and_R                   	| rstudio   	| day1_python_and_R                   	|
| day2_multi-omics                    	| jupyter   	| day2_multi-omics                    	|
| day3_interactive_visualization_iSEE 	| rstudio   	| day3_interactive_visualization_iSEE 	|
| day3_spatial_transcriptomics        	| jupyter   	| day3_spatial_transcriptomics        	|
| day4_deep_generative_networks       	| rstudio   	| day4_deep_generative_networks       	|

Scripts on how to run the containers locally can be found at `containers/container_jupyter/run_container.sh` and `containers/container_rstudio/run_container.sh` for the jupyter and rstudio containers respectively. The jupyter container  can be approached through port 8888, the rstudio container through port 8787. Both have the password test123. The username for the rstudio container is `rstudio`, the jupyter container does not require a username. 